### PR TITLE
Changed to work without ColorAxis.

### DIFF
--- a/Source/Examples/ExampleLibrary/Series/PolygonSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/PolygonSeriesExamples.cs
@@ -80,5 +80,26 @@ namespace ExampleLibrary.Series
 
             return res;
         }
+
+        [Example("WithoutColorAxis")]
+        [DocumentationExample("Series/PolygonSeries")]
+        public static PlotModel WithoutColorAxis()
+        {
+            var model = new PlotModel { Title = "Without ColorAxis", PlotType = PlotType.Cartesian };
+
+            model.Axes.Add(new LinearAxis());
+
+            var ps = new PolygonSeries();
+            var outlines = new List<DataPoint[]>();
+            for (int i = 0; i < 5; i++)
+            {
+                ps.Items.Add(new PolygonItem(RegularPolygon(new DataPoint(i * 5, 0), 2, 3 + i), i));
+                outlines.Add(RegularPolygon(new DataPoint(i * 5, 5), 2, 3 + i));
+            }
+            ps.Items.Add(new PolygonItem(outlines, 10));
+            model.Series.Add(ps);
+
+            return model;
+        }
     }
 }

--- a/Source/OxyPlot/Series/PolygonSeries.cs
+++ b/Source/OxyPlot/Series/PolygonSeries.cs
@@ -40,6 +40,7 @@
             this.LabelFormatString = "0.00";
             this.LabelFontSize = 0;
             this.Stroke = OxyColors.Undefined;
+            this.Fill = OxyColors.Undefined;
             this.StrokeThickness = 2;
         }
 
@@ -100,6 +101,12 @@
         /// </summary>
         /// <value>The stroke.</value>
         public OxyColor Stroke { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fill color of the polygon.
+        /// </summary>
+        /// <value>The fill color.</value>
+        public OxyColor Fill { get; set; }
 
         /// <summary>
         /// Gets or sets the stroke thickness. The default is <c>2</c>.
@@ -214,7 +221,11 @@
 
             foreach (var item in items)
             {
-                var polyColor = this.ColorAxis.GetColor(item.Value);
+                var polyColor = this.Fill.IsUndefined() ?
+                    this.ColorAxis?.GetColor(item.Value) ?? this.PlotModel.GetDefaultColor() :
+                    this.Fill.IsAutomatic() ?
+                        this.PlotModel.GetDefaultColor() :
+                        this.Fill;
 
                 foreach (var outline in item.Outlines)
                 {


### PR DESCRIPTION
- Add **Fill** in PolygonSeries class
- polyColor works as follows
    - If Fill Is Undefined
        - If Is ColorAxis valid
            - Get color from ColorAxis
        - Else
            - Get Default Color
    - Else
        - If Fill Is Automatic
            - Get Default Color
        - Else
            - Fill
- Added an example without ColorAixs